### PR TITLE
feat: WSL2環境での開発サーバー起動問題を解決

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,13 @@ npm install
 
 # 開発サーバーを起動
 npm run dev
+
+# WSL2環境の場合（Windows + WSL2）
+npm run dev:wsl
 ```
 
-ブラウザで `http://localhost:5173` にアクセス
+ブラウザで `http://localhost:5173` にアクセス  
+**WSL2環境の場合**: Windows側ブラウザから `http://[WSL2-IP]:5173` でアクセス
 
 ### ビルド
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:wsl": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.app.json && tsc -p tsconfig.node.json"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,5 +10,9 @@ export default defineConfig({
       $lib: path.resolve(__dirname, 'src/lib'),
     },
   },
+  server: {
+    host: true, // WSL2でWindows側からアクセス可能にする
+    port: 5173,
+  },
 })
 


### PR DESCRIPTION
🔧 変更内容:
- vite.config.ts: server.host = true でWSL2からWindows側アクセスを有効化
- package.json: WSL2用の npm run dev:wsl スクリプトを追加
- README.md: WSL2環境での起動手順とアクセス方法を追記

�� 解決した問題:
- Windows再起動後のWSL2でViteサーバーにアクセスできない問題
- localhost バインドによる外部アクセス制限

🚀 効果:
- Windows + WSL2環境での開発体験向上
- 再発防止のための永続的な設定
- 明確な環境別起動手順の提供